### PR TITLE
HA: prod/staging environment toggle

### DIFF
--- a/docs/dev/home-assistant.md
+++ b/docs/dev/home-assistant.md
@@ -78,12 +78,48 @@ After the first `task ha:deploy` and HA restart:
 
 1. **Settings → Devices & Services → Add Integration**
 2. Search for **kio**
-3. Enter:
-   - **API URL** — e.g. `http://api.kio.example.local`
-   - **API Key** — leave blank if auth is disabled
+3. Pick an **Environment**:
+   - **prod** / **staging** — auto-fills that environment's API URL and the shared
+     private-gateway IP override; you just enter that env's **API key**.
+   - **custom** — enter your own **API URL** (and an **API IP Override** if HA
+     can't resolve the hostname, e.g. the `.int` TLD).
 4. Submit — HA validates by calling `GET /kiosks`
 
 All registered kiosks appear as Devices immediately.
+
+---
+
+## Switching between prod and staging
+
+The integration can mirror either environment as its source of truth. The env
+preset lives in both the add and **Reconfigure** flows (`config_flow.py`,
+`ENV_PRESETS`): choosing `prod`/`staging` fills the URL + the shared gateway IP
+(`192.168.50.81` — both envs sit behind the same private nginx gateway with
+host-based routing), so switching is just a dropdown + that env's API key.
+
+**To flip in place:** **Settings → Devices & Services → kio → ⋮ → Reconfigure →
+Environment** → pick the other env → enter its API key → Submit. The entry
+re-points and reloads.
+
+> **Caveat — entity churn.** Switching environments changes which kiosks exist
+> (different kiosk UUIDs → different entity `unique_id`s). HA keeps the old env's
+> entities in the registry until they're purged, so the new env's entities land
+> with `_2` suffixes (`switch.office_display_power_2`, …) and the old ones linger
+> as `unavailable`. Fine for an occasional switch.
+
+**For a spotless switch (no `_2`):** delete → restart → re-add, so the old
+entities are purged before the new ones register:
+
+1. **Delete** the kio entry (Settings → Devices & Services → kio → ⋮ → Delete),
+   or `DELETE /api/config/config_entries/entry/{id}`.
+2. **`task ha:deploy`** (or any HA Core restart) — startup purges the orphaned
+   entities, freeing the base entity ids.
+3. **Re-add** via the env preset (Add Integration → kio → Environment).
+
+Notes:
+- The API key is stored **encrypted** in HA's config entry (`.storage`), per env.
+- Entry titles reflect the env (`kio (prod)` / `kio (staging)`), so a glance at
+  the integration card tells you which source is active.
 
 ---
 

--- a/src/ha-integration/custom_components/kio/config_flow.py
+++ b/src/ha-integration/custom_components/kio/config_flow.py
@@ -10,6 +10,18 @@ from .coordinator import _make_session
 
 _LOGGER = logging.getLogger(__name__)
 
+CONF_ENV = "environment"
+
+# Pick an environment and the URL/IP are filled in for you — switching which kio
+# instance HA mirrors is then just choosing staging/prod and entering that env's
+# API key. Both envs sit behind the same private gateway (host-based routing), so
+# the IP override (needed because HA can't resolve the .int hostnames) is shared.
+ENV_PRESETS: dict[str, dict[str, str]] = {
+    "staging": {CONF_API_URL: "http://api.stg.kio.colfax.int", CONF_API_IP: "192.168.50.81"},
+    "prod":    {CONF_API_URL: "http://api.kio.colfax.int",     CONF_API_IP: "192.168.50.81"},
+}
+ENV_CHOICES = ["prod", "staging", "custom"]
+
 
 async def _validate(api_url: str, api_key: str, api_ip: str = "") -> None:
     url = api_url.rstrip("/")
@@ -33,71 +45,107 @@ async def _validate(api_url: str, api_key: str, api_ip: str = "") -> None:
         raise HomeAssistantError("cannot_connect") from err
 
 
+def _resolve(user_input: dict) -> tuple[str, str, str]:
+    """(api_url, api_key, api_ip) from the form: a chosen env applies its preset;
+    `custom` uses the typed URL/IP."""
+    preset = ENV_PRESETS.get(user_input.get(CONF_ENV, "custom"))
+    if preset:
+        url, ip = preset[CONF_API_URL], preset[CONF_API_IP]
+    else:
+        url = (user_input.get(CONF_API_URL) or "").strip()
+        ip = (user_input.get(CONF_API_IP) or "").strip()
+    return url.rstrip("/"), user_input.get(CONF_API_KEY, ""), ip
+
+
+def _env_of(data: dict) -> str:
+    """Which environment an existing entry points at, for pre-selecting the form."""
+    if data.get(CONF_ENV):
+        return data[CONF_ENV]
+    url = (data.get(CONF_API_URL) or "").rstrip("/")
+    for name, preset in ENV_PRESETS.items():
+        if preset[CONF_API_URL].rstrip("/") == url:
+            return name
+    return "custom"
+
+
 def _schema(defaults: dict | None = None) -> vol.Schema:
-    """Build the connection form, pre-filling from `defaults` when reconfiguring."""
     defaults = defaults or {}
     return vol.Schema({
-        vol.Required(
-            CONF_API_URL,
-            description={"suggested_value": defaults.get(CONF_API_URL, "http://api.kio.example.local")},
-        ): str,
-        vol.Optional(
-            CONF_API_KEY,
-            description={"suggested_value": defaults.get(CONF_API_KEY, "")},
-        ): str,
-        vol.Optional(
-            CONF_API_IP,
-            description={"suggested_value": defaults.get(CONF_API_IP, "")},
-        ): str,
+        vol.Required(CONF_ENV, default=defaults.get(CONF_ENV, "prod")): vol.In(ENV_CHOICES),
+        vol.Optional(CONF_API_KEY, description={"suggested_value": defaults.get(CONF_API_KEY, "")}): str,
+        vol.Optional(CONF_API_URL, description={"suggested_value": defaults.get(CONF_API_URL, "")}): str,
+        vol.Optional(CONF_API_IP, description={"suggested_value": defaults.get(CONF_API_IP, "")}): str,
     })
+
+
+def _title(env: str) -> str:
+    return f"kio ({env})" if env in ENV_PRESETS else "kio"
 
 
 class KioConfigFlow(ConfigFlow, domain=DOMAIN):
     VERSION = 1
 
     async def async_step_user(self, user_input=None) -> ConfigFlowResult:
-        errors = {}
+        errors: dict[str, str] = {}
 
         if user_input is not None:
-            try:
-                await _validate(
-                    user_input[CONF_API_URL],
-                    user_input.get(CONF_API_KEY, ""),
-                    user_input.get(CONF_API_IP, ""),
-                )
-            except HomeAssistantError as err:
-                errors["base"] = str(err)
+            url, key, ip = _resolve(user_input)
+            env = user_input.get(CONF_ENV, "custom")
+            if not url:
+                errors["base"] = "url_required"
             else:
-                await self.async_set_unique_id(user_input[CONF_API_URL].rstrip("/"))
-                self._abort_if_unique_id_configured()
-                return self.async_create_entry(title="kio", data=user_input)
+                try:
+                    await _validate(url, key, ip)
+                except HomeAssistantError as err:
+                    errors["base"] = str(err)
+                else:
+                    await self.async_set_unique_id(url)
+                    self._abort_if_unique_id_configured()
+                    return self.async_create_entry(
+                        title=_title(env),
+                        data={CONF_ENV: env, CONF_API_URL: url, CONF_API_KEY: key, CONF_API_IP: ip},
+                    )
 
         return self.async_show_form(step_id="user", data_schema=_schema(), errors=errors)
 
     async def async_step_reconfigure(self, user_input=None) -> ConfigFlowResult:
-        """Update an existing entry's connection settings (e.g. a rotated API key).
+        """Re-point this integration at a different kio environment, or fix its key.
 
-        Lets you fix credentials without deleting and re-adding the integration.
+        Switching staging<->prod intentionally changes which instance HA mirrors
+        (and thus the entry's unique_id), so — unlike a normal reconfigure — this
+        allows the unique_id to change; it only blocks colliding with a *different*
+        already-configured entry.
         """
         entry = self._get_reconfigure_entry()
-        errors = {}
+        errors: dict[str, str] = {}
 
         if user_input is not None:
-            try:
-                await _validate(
-                    user_input[CONF_API_URL],
-                    user_input.get(CONF_API_KEY, ""),
-                    user_input.get(CONF_API_IP, ""),
-                )
-            except HomeAssistantError as err:
-                errors["base"] = str(err)
+            url, key, ip = _resolve(user_input)
+            env = user_input.get(CONF_ENV, "custom")
+            if not url:
+                errors["base"] = "url_required"
             else:
-                await self.async_set_unique_id(user_input[CONF_API_URL].rstrip("/"))
-                self._abort_if_unique_id_mismatch(reason="wrong_account")
-                return self.async_update_reload_and_abort(entry, data_updates=user_input)
+                try:
+                    await _validate(url, key, ip)
+                except HomeAssistantError as err:
+                    errors["base"] = str(err)
+                else:
+                    collision = any(
+                        e.entry_id != entry.entry_id and (e.unique_id or "") == url
+                        for e in self._async_current_entries()
+                    )
+                    if collision:
+                        return self.async_abort(reason="already_configured")
+                    await self.async_set_unique_id(url)
+                    return self.async_update_reload_and_abort(
+                        entry,
+                        title=_title(env),
+                        unique_id=url,
+                        data={CONF_ENV: env, CONF_API_URL: url, CONF_API_KEY: key, CONF_API_IP: ip},
+                    )
 
         return self.async_show_form(
             step_id="reconfigure",
-            data_schema=_schema(user_input or entry.data),
+            data_schema=_schema(user_input or {**entry.data, CONF_ENV: _env_of(entry.data)}),
             errors=errors,
         )

--- a/src/ha-integration/custom_components/kio/translations/en.json
+++ b/src/ha-integration/custom_components/kio/translations/en.json
@@ -4,39 +4,43 @@
       "user": {
         "title": "Connect to kio",
         "data": {
+          "environment": "Environment",
           "api_url": "API URL",
           "api_key": "API Key",
           "api_ip": "API IP Override"
         },
         "data_description": {
-          "api_url": "Base URL of your kio API, e.g. http://api.kio.example.local",
-          "api_key": "Optional API key (X-API-Key). Leave blank if auth is disabled.",
-          "api_ip": "Optional. If HA cannot resolve the hostname (e.g. .int TLD DNS issue), enter the server IP here (e.g. 192.168.1.10)."
+          "environment": "Pick prod or staging to fill the URL automatically, or 'custom' to enter your own.",
+          "api_url": "Only for 'custom' — base URL of your kio API, e.g. http://api.kio.example.local",
+          "api_key": "API key (X-API-Key) for the chosen environment. Leave blank if auth is disabled.",
+          "api_ip": "Only for 'custom'. If HA cannot resolve the hostname (.int TLD DNS issue), enter the server IP here."
         }
       },
       "reconfigure": {
         "title": "Reconfigure kio",
-        "description": "Update the connection settings for this kio instance, e.g. after rotating the API key.",
+        "description": "Switch which environment this integration mirrors (prod/staging), or update its API key. Switching environments changes which kiosks appear.",
         "data": {
+          "environment": "Environment",
           "api_url": "API URL",
           "api_key": "API Key",
           "api_ip": "API IP Override"
         },
         "data_description": {
-          "api_url": "Base URL of your kio API, e.g. http://api.kio.example.local",
-          "api_key": "API key (X-API-Key). Leave blank if auth is disabled.",
-          "api_ip": "Optional. If HA cannot resolve the hostname, enter the server IP here."
+          "environment": "Choose prod or staging to switch source of truth; 'custom' to enter your own URL.",
+          "api_url": "Only for 'custom' — base URL of your kio API.",
+          "api_key": "API key (X-API-Key) for the chosen environment. Leave blank if auth is disabled.",
+          "api_ip": "Only for 'custom'. If HA cannot resolve the hostname, enter the server IP here."
         }
       }
     },
     "error": {
       "cannot_connect": "Could not reach the kio API. Check the URL and network.",
-      "invalid_auth": "API key was rejected (HTTP 401)."
+      "invalid_auth": "API key was rejected (HTTP 401).",
+      "url_required": "Choose an environment, or enter an API URL for 'custom'."
     },
     "abort": {
-      "already_configured": "This kio instance is already configured.",
-      "reconfigure_successful": "kio connection settings updated.",
-      "wrong_account": "That API URL points at a different kio instance than this entry."
+      "already_configured": "This kio environment is already configured.",
+      "reconfigure_successful": "kio connection settings updated."
     }
   },
   "services": {

--- a/src/ha-integration/tests/test_config_flow.py
+++ b/src/ha-integration/tests/test_config_flow.py
@@ -3,12 +3,15 @@ from homeassistant import config_entries, data_entry_flow
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components.kio.config_flow import CONF_ENV, ENV_PRESETS
 from custom_components.kio.const import CONF_API_KEY, CONF_API_URL, DOMAIN
 
 API = "http://kio.test"
+PROD = ENV_PRESETS["prod"][CONF_API_URL].rstrip("/")
+STG = ENV_PRESETS["staging"][CONF_API_URL].rstrip("/")
 
 
-async def test_user_flow_success(hass: HomeAssistant) -> None:
+async def test_user_flow_custom_env(hass: HomeAssistant) -> None:
     with aioresponses() as m:
         m.get(f"{API}/kiosks", payload=[], repeat=True)
         result = await hass.config_entries.flow.async_init(
@@ -17,12 +20,30 @@ async def test_user_flow_success(hass: HomeAssistant) -> None:
         assert result["type"] == data_entry_flow.FlowResultType.FORM
 
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], {CONF_API_URL: API}
+            result["flow_id"], {CONF_ENV: "custom", CONF_API_URL: API}
         )
         await hass.async_block_till_done()
 
     assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_API_URL] == API
+    assert result["data"][CONF_ENV] == "custom"
+
+
+async def test_user_flow_prod_preset_fills_url(hass: HomeAssistant) -> None:
+    # Choosing the prod environment uses its preset URL — no URL typed.
+    with aioresponses() as m:
+        m.get(f"{PROD}/kiosks", payload=[], repeat=True)
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_ENV: "prod", CONF_API_KEY: "k"}
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_API_URL] == PROD
+    assert result["title"] == "kio (prod)"
 
 
 async def test_user_flow_cannot_connect(hass: HomeAssistant) -> None:
@@ -32,30 +53,34 @@ async def test_user_flow_cannot_connect(hass: HomeAssistant) -> None:
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], {CONF_API_URL: API}
+            result["flow_id"], {CONF_ENV: "custom", CONF_API_URL: API}
         )
 
     assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_reconfigure_updates_api_key(hass: HomeAssistant) -> None:
+async def test_reconfigure_switches_environment(hass: HomeAssistant) -> None:
+    # Start pointed at staging, switch to prod — unique_id + data follow the env.
     entry = MockConfigEntry(
-        domain=DOMAIN, unique_id=API, data={CONF_API_URL: API, CONF_API_KEY: "old"}
+        domain=DOMAIN, unique_id=STG,
+        data={CONF_ENV: "staging", CONF_API_URL: STG, CONF_API_KEY: "old"},
     )
     entry.add_to_hass(hass)
 
     with aioresponses() as m:
-        m.get(f"{API}/kiosks", payload=[], repeat=True)
+        m.get(f"{PROD}/kiosks", payload=[], repeat=True)
         result = await entry.start_reconfigure_flow(hass)
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "reconfigure"
 
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], {CONF_API_URL: API, CONF_API_KEY: "new-key"}
+            result["flow_id"], {CONF_ENV: "prod", CONF_API_KEY: "prod-key"}
         )
         await hass.async_block_till_done()
 
     assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
-    assert entry.data[CONF_API_KEY] == "new-key"
+    assert entry.data[CONF_API_URL] == PROD
+    assert entry.data[CONF_ENV] == "prod"
+    assert entry.data[CONF_API_KEY] == "prod-key"
+    assert entry.unique_id == PROD


### PR DESCRIPTION
## Summary
Lets the Home Assistant integration switch which kio environment it mirrors (prod vs staging) as its source of truth, without hand-typing URLs.

## Changes
- **Environment preset selector** in both the add and **Reconfigure** flows (`config_flow.py`): choosing `prod`/`staging` auto-fills that env's API URL and the shared private-gateway IP override (`192.168.50.81`, host-based routing) — you only supply that env's API key. `custom` still allows a manual URL/IP.
- **Reconfigure can switch environments:** it now allows the entry's `unique_id` to change (since switching intentionally points at a different instance), blocking only a collision with another configured entry. Entry titles become `kio (prod)` / `kio (staging)`.
- **Docs:** new "Switching between prod and staging" section in `docs/dev/home-assistant.md` — the preset, the in-place Reconfigure toggle and its `_2` entity-churn caveat, the clean delete → restart → re-add procedure, and that the API key is stored encrypted per env. First-time setup updated for the Environment field.

## Notes
- Switching environments changes which kiosks exist, so the old env's entities go `unavailable` and the new env's are created — expected for a source switch (documented).
- HA integration deploys independently via `task ha:deploy` (already live on the box); this PR codifies it on the main line.

## Test plan
- `task ha:test` — 6 pass, including the new env-preset add flow and a staging→prod reconfigure switch.