### PR TITLE
CI: Tests PR-gate + emoji step summaries on all workflows

### DIFF
--- a/.github/workflows/ha-integration.yaml
+++ b/.github/workflows/ha-integration.yaml
@@ -27,4 +27,19 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
       - name: Run tests
-        run: uv run --with-requirements requirements_test.txt pytest -q
+        id: test
+        run: |
+          set -o pipefail
+          uv run --with-requirements requirements_test.txt pytest -q 2>&1 | tee /tmp/ha.txt
+      - name: 📋 Summary
+        if: always()
+        run: |
+          line=$(grep -ohE '[0-9]+ (passed|failed|error)[a-z0-9 ,.]*' /tmp/ha.txt | tail -1 || true)
+          if [ "${{ steps.test.outcome }}" = "success" ]; then head="## ✅ 🏠 HA integration tests passed"; else head="## ❌ 🏠 HA integration tests failed"; fi
+          {
+            echo "$head"
+            echo ""
+            echo "🧩 Home Assistant custom-component suite (config flow + entity setup)"
+            echo ""
+            echo "> 📊 \`${line:-see job logs}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/prd.yaml
+++ b/.github/workflows/prd.yaml
@@ -44,7 +44,10 @@ jobs:
           echo "$HOME/bin" >> "$GITHUB_PATH"
 
       - name: Unit tests
-        run: task test:api:docker
+        id: unit
+        run: |
+          set -o pipefail
+          task test:api:docker 2>&1 | tee /tmp/unit.txt
 
       - name: Release gate ([skip release] in commit message?)
         id: gate
@@ -97,3 +100,32 @@ jobs:
           git push origin "HEAD:${GITHUB_REF_NAME}"
           git push origin "v${VERSION}"
           echo "::notice::Released v${VERSION} — ArgoCD will sync prd (migrate hook → rollout)."
+
+      - name: 📋 Release summary
+        if: always()
+        run: |
+          UNIT=$(grep -ohE '[0-9]+ (passed|failed|error)[a-z0-9 ,.]*' /tmp/unit.txt 2>/dev/null | tail -1 || true)
+          VERSION="$(cat VERSION 2>/dev/null || echo '?')"
+          {
+            echo "# 🚀 kio PRD pipeline"
+            echo ""
+            echo "🌿 Branch \`${GITHUB_REF_NAME}\` · 🧪 Unit tests: \`${UNIT:-see logs}\`"
+            echo ""
+            if [ "${{ job.status }}" != "success" ]; then
+              echo "## ❌ Pipeline failed"
+              echo ""
+              echo "🔎 Check the failing step above — no release was published."
+            elif [ "${{ steps.gate.outputs.skip }}" = "true" ]; then
+              echo "## ⏭️ Tests only — release skipped"
+              echo ""
+              echo "💬 Commit message contained \`[skip release]\` — ✅ tests ran, no version cut."
+            else
+              echo "## ✅ Released \`v${VERSION}\` 🎉"
+              echo ""
+              echo "| 🏷️ Version | 🐳 Images | 📦 Registry |"
+              echo "| --- | --- | --- |"
+              echo "| \`v${VERSION}\` | \`kio-api:${VERSION}\` · \`kio-ui:${VERSION}\` | \`harbor.squid-ink.us/politeauthority\` |"
+              echo ""
+              echo "🏷️ Tag \`v${VERSION}\` pushed · 🔄 ArgoCD prd syncs (⚠️ migrate hook → rollout) on the branch it tracks."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/stg.yaml
+++ b/.github/workflows/stg.yaml
@@ -40,7 +40,10 @@ jobs:
           echo "$HOME/bin" >> "$GITHUB_PATH"
 
       - name: Unit tests
-        run: task test:api:docker
+        id: unit
+        run: |
+          set -o pipefail
+          task test:api:docker 2>&1 | tee /tmp/unit.txt
 
       - name: Compute PR tag + namespace
         id: meta
@@ -63,6 +66,29 @@ jobs:
           task push-stg     BRANCH=pr-${{ github.event.number }}
           task build-ui-stg BRANCH=pr-${{ github.event.number }}
           task push-ui-stg  BRANCH=pr-${{ github.event.number }}
+
+      - name: 📋 Build summary
+        if: always()
+        run: |
+          UNIT=$(grep -ohE '[0-9]+ (passed|failed|error)[a-z0-9 ,.]*' /tmp/unit.txt 2>/dev/null | tail -1 || true)
+          TAG="stg-pr-${{ github.event.number }}"
+          {
+            echo "# 🧪 kio STG · PR #${{ github.event.number }}"
+            echo ""
+            echo "🧪 Unit tests: \`${UNIT:-see logs}\`"
+            echo ""
+            if [ "${{ job.status }}" = "success" ]; then
+              echo "## ✅ Staging images built & pushed"
+              echo ""
+              echo "| 🏷️ Tag | 🐳 Images | 🧭 Ephemeral env |"
+              echo "| --- | --- | --- |"
+              echo "| \`${TAG}\` | \`kio-api:${TAG}\` · \`kio-ui:${TAG}\` | \`kio-stg-pr-${{ github.event.number }}\` |"
+              echo ""
+              echo "🔄 ArgoCD's PR ApplicationSet deploys these tags; 🔁 regression runs next."
+            else
+              echo "## ❌ Build / unit tests failed — see logs above."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
   regression:
     needs: test-build
@@ -101,6 +127,22 @@ jobs:
           task test:e2e:api
           task test:e2e:ui
 
+      - name: 📋 Regression summary
+        if: always()
+        run: |
+          NS="${{ needs.test-build.outputs.namespace }}"
+          {
+            if [ "${{ job.status }}" = "success" ]; then
+              echo "## ✅ 🔁 Regression passed — PR #${{ github.event.number }}"
+              echo ""
+              echo "🌐 e2e (API + UI) green against \`${NS}\`."
+            else
+              echo "## ❌ 🔁 Regression failed — PR #${{ github.event.number }}"
+              echo ""
+              echo "🔎 Ephemeral env \`${NS}\` — check rollout / e2e logs above."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
   promote:
     needs: regression
     runs-on: kio
@@ -111,4 +153,6 @@ jobs:
       name: staging
     steps:
       - name: Approved
-        run: echo "Staging approved for PR #${{ github.event.number }}."
+        run: |
+          echo "Staging approved for PR #${{ github.event.number }}."
+          echo "## 🎉 ✅ Staging approved — PR #${{ github.event.number }} is promote / merge-ready" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,108 @@
+name: Tests
+
+# 🧪 Full test-suite gate for pull requests into main or staging. Runs every
+# environment-independent suite (API unit, pi-agent, HA integration) in
+# parallel and writes a per-suite summary. Environment-dependent e2e tests
+# (task test:e2e:*) are intentionally excluded — they need a live deployment
+# (see stg.yaml's regression job).
+
+on:
+  pull_request:
+    branches: [main, staging]
+
+concurrency:
+  group: tests-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  api-unit:
+    name: API unit tests
+    runs-on: kio   # task test:api:docker needs Docker (DinD)
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install task
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/bin"
+          curl -fsSL https://taskfile.dev/install.sh | sh -s -- -b "$HOME/bin"
+          echo "$HOME/bin" >> "$GITHUB_PATH"
+      - name: Run API unit tests (docker)
+        id: test
+        run: |
+          set -o pipefail
+          task test:api:docker 2>&1 | tee /tmp/api.txt
+      - name: 📋 Summary
+        if: always()
+        run: |
+          line=$(grep -ohE '[0-9]+ (passed|failed|error)[a-z0-9 ,.]*' /tmp/api.txt | tail -1 || true)
+          if [ "${{ steps.test.outcome }}" = "success" ]; then head="### ✅ 🐍 API unit tests passed"; else head="### ❌ 🐍 API unit tests failed"; fi
+          {
+            echo "$head"
+            echo ""
+            echo "🔬 \`task test:api:docker\` — pytest inside the prod-mirror image"
+            echo ""
+            echo "> 📊 \`${line:-see job logs}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  pi-agent:
+    name: pi-agent unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - name: Install task
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/bin"
+          curl -fsSL https://taskfile.dev/install.sh | sh -s -- -b "$HOME/bin"
+          echo "$HOME/bin" >> "$GITHUB_PATH"
+      - name: Run pi-agent unit tests
+        id: test
+        run: |
+          set -o pipefail
+          task test:pi-agent 2>&1 | tee /tmp/pi.txt
+      - name: 📋 Summary
+        if: always()
+        run: |
+          line=$(grep -ohE '[0-9]+ (passed|failed|error)[a-z0-9 ,.]*' /tmp/pi.txt | tail -1 || true)
+          if [ "${{ steps.test.outcome }}" = "success" ]; then head="### ✅ 🥧 pi-agent unit tests passed"; else head="### ❌ 🥧 pi-agent unit tests failed"; fi
+          {
+            echo "$head"
+            echo ""
+            echo "🔬 \`task test:pi-agent\` — pytest for the Raspberry Pi agent"
+            echo ""
+            echo "> 📊 \`${line:-see job logs}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  ha-integration:
+    name: HA integration tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - name: Install task
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/bin"
+          curl -fsSL https://taskfile.dev/install.sh | sh -s -- -b "$HOME/bin"
+          echo "$HOME/bin" >> "$GITHUB_PATH"
+      - name: Run HA integration tests
+        id: test
+        run: |
+          set -o pipefail
+          task ha:test 2>&1 | tee /tmp/ha.txt
+      - name: 📋 Summary
+        if: always()
+        run: |
+          line=$(grep -ohE '[0-9]+ (passed|failed|error)[a-z0-9 ,.]*' /tmp/ha.txt | tail -1 || true)
+          if [ "${{ steps.test.outcome }}" = "success" ]; then head="### ✅ 🏠 HA integration tests passed"; else head="### ❌ 🏠 HA integration tests failed"; fi
+          {
+            echo "$head"
+            echo ""
+            echo "🔬 \`task ha:test\` — Home Assistant custom-component suite"
+            echo ""
+            echo "> 📊 \`${line:-see job logs}\`"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## 🧪 New `tests.yaml` — full test gate on PRs into `main`/`staging`
Runs every environment-independent suite in parallel, each with its own summary:
- 🐍 **API unit** — `task test:api:docker` (131 tests) — on the `kio` ARC runner (DinD)
- 🥧 **pi-agent** — `task test:pi-agent` (72 tests)
- 🏠 **HA integration** — `task ha:test` (6 tests)

e2e (`task test:e2e:*`) is intentionally excluded — it needs a live deployment (that's `stg.yaml`'s regression job). All three suites validated green locally (209 tests).

## 📋 Emoji step summaries on every workflow
Each run now writes a `$GITHUB_STEP_SUMMARY` surfacing the important info:
- 🚀 **prd** — released version, 🐳 images + registry, or ⏭️ "tests only" when `[skip release]`
- 🧪 **stg** — PR staging tag, images, ephemeral env, 🔁 regression result, 🎉 promote gate
- 🏠 **ha-integration** & **tests** — per-suite pass/fail + test counts

## ⚠️ Notes
- `prd`/`stg`/`ha-integration` still trigger on `[main, cicd]`, but `cicd` was deleted after the #17 merge — that ref is now dead. Say the word and I'll switch those to `[main, staging]`.
- For the `tests` gate to fire on PRs *into* `main`, `tests.yaml` must live on `main` (pull_request workflows run from the base branch) — it reaches `main` when this branch is promoted there.