### PR TITLE
ci: use the shared robot$ci harbor account

### DIFF
--- a/.github/workflows/prd.yaml
+++ b/.github/workflows/prd.yaml
@@ -64,7 +64,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: harbor.squid-ink.us
-          username: robot$kio-ci
+          username: robot$ci
           password: ${{ secrets.HARBOR_PASSWORD }}
 
       - name: Bump patch version

--- a/.github/workflows/stg.yaml
+++ b/.github/workflows/stg.yaml
@@ -55,7 +55,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: harbor.squid-ink.us
-          username: robot$kio-ci
+          username: robot$ci
           password: ${{ secrets.HARBOR_PASSWORD }}
 
       - name: Build & push staging images (test target)


### PR DESCRIPTION
Part of consolidating all repos onto one Harbor CI robot (robot$ci). The HARBOR_PASSWORD secret on this repo has already been rotated to robot$ci's token, so the hardcoded robot$kio-ci usernames must switch with it. robot$kio-ci itself is untouched and still valid until this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)